### PR TITLE
Add freeze and fetch -rebuild

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -72,7 +72,7 @@ Flags:
 			}
 			path := args[0]
 			recurse = !noRecurse
-			return fetch(path, recurse, true)
+			return fetch(path, recurse)
 		default:
 			return fmt.Errorf("more than one import path supplied")
 		}
@@ -92,7 +92,7 @@ func rebuild_vendor() error {
 			m.RemoveDependency(p)
 			vendor.WriteManifest(manifestFile(), m)
 			revision = p.Revision
-			err = fetch(p.Importpath, false, false)
+			err = fetch(p.Importpath, false)
 			if err != nil {
 				return err
 			}
@@ -102,7 +102,7 @@ func rebuild_vendor() error {
 	return err
 }
 
-func fetch(path string, recurse bool, exists_check bool) error {
+func fetch(path string, recurse bool) error {
 	m, err := vendor.ReadManifest(manifestFile())
 	if err != nil {
 		return fmt.Errorf("could not load manifest: %v", err)
@@ -117,7 +117,7 @@ func fetch(path string, recurse bool, exists_check bool) error {
 	// encoded in the repo.
 	path = stripscheme(path)
 
-	if exists_check && m.HasImportpath(path) {
+	if m.HasImportpath(path) {
 		return fmt.Errorf("%s is already vendored", path)
 	}
 
@@ -212,7 +212,7 @@ func fetch(path string, recurse bool, exists_check bool) error {
 			sort.Strings(vkeys)
 			pkg := vkeys[0]
 			log.Printf("fetching recursive dependency %s", pkg)
-			if err := fetch(pkg, false, exists_check); err != nil {
+			if err := fetch(pkg, false); err != nil {
 				return err
 			}
 		}

--- a/freeze.go
+++ b/freeze.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/FiloSottile/gvt/gbvendor"
+)
+
+var (
+	freezeAll bool // freeze all dependencies
+)
+
+func addFreezeFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&freezeAll, "all", false, "freeze all dependencies")
+	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
+}
+
+var cmdFreeze = &Command{
+	Name:      "freeze",
+	UsageLine: "freeze [-all] import",
+	Short:     "freeze a local dependency",
+	Long: `Freezes the dependency (or all if specified) to allow locking in a specific version.
+Useful for 'enterprise' environments where you want everyone to have the same version of a
+dependency. This allows users to quickly 'gvt fetch importpath' and later lock in the version
+they are using.
+
+Flags:
+	-all
+		will freeze all dependencies in the manifest, otherwise only the dependency supplied.
+
+`,
+	Run: func(args []string) error {
+		if len(args) != 1 && !freezeAll {
+			return fmt.Errorf("freeze: import path or --all flag is missing")
+		} else if len(args) == 1 && freezeAll {
+			return fmt.Errorf("freeze: you cannot specify path and --all flag at once")
+		}
+
+		m, err := vendor.ReadManifest(manifestFile())
+		if err != nil {
+			return fmt.Errorf("could not load manifest: %v", err)
+		}
+
+		var dependencies []vendor.Dependency
+		if freezeAll {
+			dependencies = make([]vendor.Dependency, len(m.Dependencies))
+			copy(dependencies, m.Dependencies)
+		} else {
+			p := args[0]
+			dependency, err := m.GetDependencyForImportpath(p)
+			if err != nil {
+				return fmt.Errorf("could not get dependency: %v", err)
+			}
+			dependencies = append(dependencies, dependency)
+		}
+
+		for _, d := range dependencies {
+			err = m.RemoveDependency(d)
+			if err != nil {
+				return fmt.Errorf("dependency could not be deleted from manifest: %v", err)
+			}
+
+			dep := vendor.Dependency{
+				Importpath: d.Importpath,
+				Repository: d.Repository,
+				Revision:   d.Revision,
+				Branch:     "HEAD",
+				Path:       d.Path,
+			}
+
+			if err := m.AddDependency(dep); err != nil {
+				return err
+			}
+
+			if err := vendor.WriteManifest(manifestFile(), m); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	AddFlags: addFreezeFlags,
+}

--- a/freeze.go
+++ b/freeze.go
@@ -12,7 +12,6 @@ var (
 
 func addFreezeFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&freezeAll, "all", false, "freeze all dependencies")
-	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
 }
 
 var cmdFreeze = &Command{

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var commands = []*Command{
 	cmdUpdate,
 	cmdList,
 	cmdDelete,
+	cmdFreeze,
 }
 
 func main() {


### PR DESCRIPTION
I figured these could be useful to others. It allows you to freeze versions and later repull exactly what you had if you check your vendor manifest into your repo without having to check in the source code for the projects in your manifest file.
