### PR TITLE
Adding list filter option for orphan deps

### DIFF
--- a/alldocs.go
+++ b/alldocs.go
@@ -87,7 +87,7 @@ Flags:
 List dependencies one per line
 
 Usage:
-        gvt list [-f format]
+        gvt list [-f format] [-orphan]
 
 list formats the contents of the manifest file.
 
@@ -95,6 +95,8 @@ Flags:
 	-f
 		controls the template used for printing each manifest entry. If not supplied
 		the default value is "{{.Importpath}}\t{{.Repository}}{{.Path}}\t{{.Branch}}\t{{.Revision}}"
+	-orphan
+		filters the list for dependencies that currently are not being referenced.
 
 Delete a local dependency
 


### PR DESCRIPTION
This PR will add the option to list dependencies that are not being imported currently. I have found this feature quite useful, but not sure if it is part of the `gvt` project goal. Currently, the only option to get the unused packages is through the [ `go list`](https://github.com/aminjam/go-bootable/blob/master/scripts/deps.bash#L4-L10). There wasn't any test coverage on any of the commands, but I'd be happy to add one if there is a convention you'd like me to follow.

Use case: `gvt list -orphan`
