### PR TITLE
Fix shortened url typo

### DIFF
--- a/gbvendor/manifest.go
+++ b/gbvendor/manifest.go
@@ -181,7 +181,7 @@ func ReadManifest(path string) (*Manifest, error) {
 	for _, d := range deps {
 		if err := m.AddDependency(d); err == DepPresent {
 			log.Println("WARNING: overlapping dependency detected:", d.Importpath)
-			log.Println("The subpackage will be ignored to fix undefined behavior. See https://git.io/vwK4B")
+			log.Println("The subpackage will be ignored to fix undefined behavior. See https://git.io/vr8Mu")
 		} else if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Got a warning message with a shortened link (https://git.io/vwK4B) that was pointing to an anchor that had a typo:

![screen shot 2016-05-18 at 15 27 07](https://cloud.githubusercontent.com/assets/444856/15360232/18793cde-1d0d-11e6-916f-f2e62400010e.png)

The url was https://github.com/FiloSottile/gvt#operlapping-dependencies, the new shortened url fixes it.
