### PR TITLE
only consider full import path

### DIFF
--- a/gbvendor/manifest.go
+++ b/gbvendor/manifest.go
@@ -78,7 +78,7 @@ func (m *Manifest) GetDependencyForImportpath(path string) (Dependency, error) {
 // of the given import path.
 func (m *Manifest) GetSubpackages(path string) (deps []Dependency) {
 	for _, d := range m.Dependencies {
-		if path != d.Importpath && strings.HasPrefix(d.Importpath+"/", path+"/") {
+		if path != d.Importpath && strings.HasPrefix(d.Importpath, path+"/") {
 			deps = append(deps, d)
 		}
 	}

--- a/gbvendor/manifest.go
+++ b/gbvendor/manifest.go
@@ -78,7 +78,7 @@ func (m *Manifest) GetDependencyForImportpath(path string) (Dependency, error) {
 // of the given import path.
 func (m *Manifest) GetSubpackages(path string) (deps []Dependency) {
 	for _, d := range m.Dependencies {
-		if path != d.Importpath && strings.HasPrefix(d.Importpath, path) {
+		if path != d.Importpath && strings.HasPrefix(d.Importpath+"/", path+"/") {
 			deps = append(deps, d)
 		}
 	}


### PR DESCRIPTION
prior to this change `gvt update -all` would fail with "subpackages of this dependency are already present" for "github.com/dgryski/go-bits" against "github.com/dgryski/go-bitstream"
