### PR TITLE
Allow restoring directory start with `_`

### DIFF
--- a/fileutils/fileutils.go
+++ b/fileutils/fileutils.go
@@ -53,11 +53,12 @@ func ShouldSkip(path string, info os.FileInfo, tests, all bool) bool {
 	case tests && testdata:
 		skip = false
 
+	// https://github.com/FiloSottile/gvt/issues/85
 	// https://golang.org/cmd/go/#hdr-Description_of_package_lists
-	case strings.HasPrefix(name, "."):
-		skip = true
-	case strings.HasPrefix(name, "_") && name != "_testdata":
-		skip = true
+	// case strings.HasPrefix(name, "."):
+	// 	skip = true
+	// case strings.HasPrefix(name, "_") && name != "_testdata":
+	// 	skip = true
 
 	case !tests && name == "_testdata" && info.IsDir():
 		skip = true


### PR DESCRIPTION
May fix https://github.com/FiloSottile/gvt/issues/85

You can use this version of gvt by
```
go get -u github.com/nota/gvt
```
