### PR TITLE
Allow partial restore for vendoring a different fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ vendor it at the original import path.
 
 Since this is not a common use-case, there's no support in `gvt fetch` for it,
 however, you can manually edit the `vendor/manifest` file, changing `repository`
-and `revision`, and then run `gvt restore`.
+and `revision`, and then run `gvt restore --filter=github.com/MyOrg/MyVendoredLib`.
 
 `gvt update` will stay on your fork.
 


### PR DESCRIPTION
I was getting lost in https://github.com/weaveworks/scope/pull/2518 when making changes both on the app and on the vendored library. With this patch, I could run:
```
gvt restore --filter=github.com/weaveworks/tcptracer-bpf
```
Without getting distracted by the other dependencies.

/cc @iaguis @schu @2opremio
